### PR TITLE
fix regex to clean up old snapshots

### DIFF
--- a/gce-disk-snapshot.py
+++ b/gce-disk-snapshot.py
@@ -59,7 +59,7 @@ def cleanup_old_snapshots(snap_name):
   # gcloud compute snapshots list -r ^prod-1-media-content-1a.* --uri
   write_log('Performing cleanup ...')
   try:
-    result = gcloud('compute','snapshots', 'list', '-r', '^' + snap_name + '.*', '--uri')
+    result = gcloud('compute','snapshots', 'list', '-r', '^' + snap_name + '-[0-9]{6}.*', '--uri')
   except Exception as ex:
     set_last_error('GCloud execution error: %s' % ex.stderr)
     write_log(last_error,syslog.LOG_ERR)


### PR DESCRIPTION
The original regex pattern would incorrectly capture and clean up snapshots for disks with similar base names. 

For example say I have 1 VM with 2 disks named disk-vm01 and disk-vm01-data, and I want to keep 5 historical snapshots of each. When creating snapshots of disk-vm01-data everything would work correctly, and any snapshots beyond the newest 5 would be removed.

However, when cleaning up the snapshots for disk-vm01, the regex pattern would match snapshots for both disk-vm01 and disk-vm01-data. Once the combined number of snapshots for both disks exceeded 5 the script would begin to run the cleanup routine. Because of the sort order, once the snapshot count reached 5 for disk-vm01-data, ALL snapshots for disk-vm01 would be deleted immediately after creation.

This updates the regex pattern to recognize when the disk name is followed by a 6 digit date, which is how the script names the snapshots.