### PR TITLE
Allow staged backups

### DIFF
--- a/gce-disk-snapshot.py
+++ b/gce-disk-snapshot.py
@@ -66,7 +66,10 @@ def cleanup_old_snapshots(snap_name):
   # gcloud compute snapshots list -r ^prod-1-media-content-1a.* --uri
   write_log('Performing cleanup ...')
   try:
-    result = gcloud('compute','snapshots', 'list', '-r', '^' + snap_name + '-[0-9]{6}.*', '--filter=labels.snaptype=' + snapshot_label, '--uri')
+    if can_add_label():
+      result = gcloud('compute','snapshots', 'list', '-r', '^' + snap_name + '-[0-9]{6}.*', '--filter=labels.snaptype=' + snapshot_label, '--uri')
+    else:
+      result = gcloud('compute','snapshots', 'list', '-r', '^' + snap_name + '-[0-9]{6}.*', '--uri')
   except Exception as ex:
     set_last_error('GCloud execution error: %s' % ex.stderr)
     write_log(last_error,syslog.LOG_ERR)
@@ -145,7 +148,7 @@ historic_snapshots = args['history']
 status_dir = args['statdir']
 status_filename = status_dir+'/'+disk_name+'.status'
 
-if args['label']:
+if args['label'] != snapshot_label:
   if can_add_label():
     snapshot_label = args['label']
   else:


### PR DESCRIPTION
Adding logic to allow multiple levels of granularity of backup frequency.  This allows tiered backup frequency such as:
* Take snaps every 15 minutes and keep 8 snaps
* Take snaps every 1 hour and keep 24 snaps
* Take snaps every 1 day and keep 7 snaps
* etc. 

This allows greater granularity for restores while making it easier to navigate the list of available restore points.