### PR TITLE
Feature adding an arbitrary "cycle" for varying retention policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ optional arguments:
   -h, --help                         show this help message and exit
   -d DISK, --disk DISK               Disk name
   -z ZONE, --zone ZONE               The GCE zone of the disk to be imaged
-  -c CYCLE, --cycle CYCLE            The frequency of the snapshot cycle (ex: hourly, daily, weekly, monthly)
+  -c CYCLE, --cycle CYCLE            The arbitary name of your snapshot cycle (ex: hourly, daily, weekly, monthly)
   -H HISTORY, --history HISTORY      Number of historic snapshots to keep
   -s STATDIR, --statdir STATDIR      Directory where to write the status file
 ```

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@ GCE-Disk-Snapshot
  Usage:
 --------
 
-gce-disk-snapshot.py [-h] -d DISK -z ZONE [-H HISTORY] [-s STATDIR]
+`gce-disk-snapshot.py [-h] -d DISK -z ZONE [-H HISTORY] [-s STATDIR]`
 
 GCE Disk Snapshot Maker
 
+```
 optional arguments:
   -h, --help                         show this help message and exit
   -d DISK, --disk DISK               Disk name
   -z ZONE, --zone ZONE               The GCE zone of the disk to be imaged
+  -c CYCLE, --cycle CYCLE            The frequency of the snapshot cycle (ex: hourly, daily, weekly, monthly)
   -H HISTORY, --history HISTORY      Number of historic snapshots to keep
   -s STATDIR, --statdir STATDIR      Directory where to write the status file
+```
 
 License
 -------

--- a/gce-disk-snapshot.py
+++ b/gce-disk-snapshot.py
@@ -9,7 +9,7 @@
 #   -h, --help                         show this help message and exit
 #   -d DISK, --disk DISK               Disk name
 #   -z ZONE, --zone ZONE               The GCE zone of the disk to be imaged
-#   -c CYCLE, --cycle CYCLE            The frequency of the snapshot cycle (ex: hourly, daily, weekly, monthly)
+#   -c CYCLE, --cycle CYCLE            The arbitary name of your snapshot cycle (ex: hourly, daily, weekly, monthly)
 #   -H HISTORY, --history HISTORY      Number of historic snapshots to keep
 #   -s STATDIR, --statdir STATDIR      Directory where to write the status file
 #

--- a/gce-disk-snapshot.py
+++ b/gce-disk-snapshot.py
@@ -95,7 +95,7 @@ def create_snapshot(disk_name,cycle_name,gc_zone):
     write_log('Creating '+cycle_name+' snapshot for disk "'+disk_name+'" ...')
     snapshot_name = disk_name + '-' + cycle_name + '-' + time.strftime('%Y%m%d-%H%M')
   try:
-    result = gcloud('compute', 'disks', 'snapshot', disk_name, '--snapshot-names', snapshot_name, '--zone', gc_zone)
+    result = gcloud('compute', 'disks', 'snapshot', disk_name, '--async', '--snapshot-names', snapshot_name, '--zone', gc_zone)
     write_log('Snapshot created: ' + snapshot_name)
   except Exception as ex:
     set_last_error('GCloud execution error: %s' % ex.stderr)

--- a/gce-disk-snapshot.py
+++ b/gce-disk-snapshot.py
@@ -52,10 +52,10 @@ def set_last_error(error_msg):
 
 def write_log(msg,msg_type=syslog.LOG_INFO):
   try:
-    print msg
+    print(msg)
     syslog.syslog(msg_type, msg)
   except Exception as ex:
-    print 'Logging exception: %s' % ex
+    print ('Logging exception: %s' % ex)
 
 def cleanup_old_snapshots(snap_name,cycle_name):
   # gcloud compute snapshots list -r ^prod-1-media-content-1a.* --uri


### PR DESCRIPTION
Running these snapshots with cron for different retention cycles (e.g. hourly, daily, weekly, etc) the cleanup only allows specifying the number of snapshots to keep.

This feature adds an arbitrary "cycle" name to the snapshot name which will allow varying policies to each have their own number of retained snapshots(`-H`), such as 24 hourly, 30 daily, 4 weekly while still using the same underlying disk as the snapshot source.